### PR TITLE
rework for winners select stage determination

### DIFF
--- a/launchpad-common/src/launch_stage.rs
+++ b/launchpad-common/src/launch_stage.rs
@@ -35,17 +35,7 @@ pub trait LaunchStageModule: crate::config::ConfigModule {
 
         let both_selection_steps_completed =
             flags.were_winners_selected && flags.was_additional_step_completed;
-        if flags.has_winner_selection_process_started && !both_selection_steps_completed {
-            return LaunchStage::WinnerSelection;
-        }
-
-        if config.winner_selection_start_block == config.claim_start_block
-            && current_block == config.winner_selection_start_block
-        {
-            if flags.were_winners_selected {
-                return LaunchStage::Claim;
-            }
-
+        if current_block >= config.winner_selection_start_block && !both_selection_steps_completed {
             return LaunchStage::WinnerSelection;
         }
         if current_block >= config.winner_selection_start_block


### PR DESCRIPTION
Simplified the conditions for determining winners select & claim stages and avoid the risk of running into a refund situation due to missed blocks deadline.
This is more important right now since block deadlines are way much closer and anything can happen in between.